### PR TITLE
Career Line Projections

### DIFF
--- a/visualization/scatter_plot.js
+++ b/visualization/scatter_plot.js
@@ -55,8 +55,25 @@ const updateYAxis = () => {
 
 const updateXAxis = () => {
 	if (shownPlayers.length == 0) return;
-	xScale.domain([ d3.min(shownPlayers, xValue) - 10, d3.max(shownPlayers, xValue) + 20 ]);
+
+	//TODO: If we don't start at x=0, will need to re-calculate slope
+	// xScale.domain([ d3.min(shownPlayers, xValue) - 10, d3.max(shownPlayers, xValue) + 20 ]);
+	xScale.domain([ 0, d3.max(shownPlayers, xValue) + 20 ]);
 	svg.select('.x-axis').call(xAxis);
+};
+
+const calculateProjectedFinishXValue = () => {
+	const xMax = xScale.domain()[1];
+	return xScale(xMax);
+};
+
+const calculateProjectedFinishYValue = (d) => {
+	const xMax = xScale.domain()[1];
+	const rise = yValue(d);
+	const run = d.G;
+	const slope = rise / run;
+	const projectedFinish = xMax * slope;
+	return yScale(projectedFinish);
 };
 
 const addOrRemoveProjectionLines = () => {
@@ -70,8 +87,8 @@ const addOrRemoveProjectionLines = () => {
 		.attr('class', 'projectionLine')
 		.attr('x1', xScale(0))
 		.attr('y1', yScale(0))
-		.attr('x2', xMap)
-		.attr('y2', yMap)
+		.attr('x2', calculateProjectedFinishXValue())
+		.attr('y2', (d) => calculateProjectedFinishYValue(d))
 		.style('stroke', 'black')
 		.style('opacity', 0);
 
@@ -95,8 +112,10 @@ const updateScatterPlotDotAndLabelPositions = () => {
 		return xMap(d);
 	});
 
-	const projectionLinesTransition = svg.selectAll('.projectionLine').transition().duration(500).attr('y2', yMap);
-	projectionLinesTransition.transition().duration(500).attr('x2', xMap);
+	svg
+		.selectAll('.projectionLine')
+		.attr('x2', calculateProjectedFinishXValue())
+		.attr('y2', (d) => calculateProjectedFinishYValue(d));
 };
 
 const updateScatterPlotYValues = (checkedAttributes, sliderAttributes) => {
@@ -199,8 +218,8 @@ const updateScatterPlotXValues = (playerCheckbox) => {
 	dot.exit().remove();
 
 	addOrRemoveDotLabels();
-	updateScatterPlotDotAndLabelPositions();
 	addOrRemoveProjectionLines();
+	updateScatterPlotDotAndLabelPositions();
 };
 
 const updatePlot = () => {

--- a/visualization/scatter_plot.js
+++ b/visualization/scatter_plot.js
@@ -59,6 +59,25 @@ const updateXAxis = () => {
 	svg.select('.x-axis').call(xAxis);
 };
 
+const addOrRemoveProjectionLines = () => {
+	const projectionLines = svg.selectAll('.projectionLine').data(shownPlayers, function(d) {
+		return d.Player;
+	});
+
+	projectionLines
+		.enter()
+		.append('line')
+		.attr('class', 'projectionLine')
+		.attr('x1', xScale(0))
+		.attr('y1', yScale(0))
+		.attr('x2', xMap)
+		.attr('y2', yMap)
+		.style('stroke', 'black')
+		.style('opacity', 0);
+
+	projectionLines.exit().remove();
+};
+
 /*
  We need to chain the transitions as we cannot have > 1 transition on the same object at a time.
  Since updating both the X and Y positions transition the same elements, clicking too quickly will cancel the other.
@@ -75,6 +94,9 @@ const updateScatterPlotDotAndLabelPositions = () => {
 	playerNamesVerticalTransition.transition().duration(500).attr('x', (d) => {
 		return xMap(d);
 	});
+
+	const projectionLinesTransition = svg.selectAll('.projectionLine').transition().duration(500).attr('y2', yMap);
+	projectionLinesTransition.transition().duration(500).attr('x2', xMap);
 };
 
 const updateScatterPlotYValues = (checkedAttributes, sliderAttributes) => {
@@ -152,6 +174,10 @@ const updateScatterPlotXValues = (playerCheckbox) => {
 				.style('left', d3.event.pageX + 70 + 'px')
 				.style('top', d3.event.pageY - 40 + 'px');
 
+			svg.selectAll('.projectionLine').style('opacity', function(data) {
+				return d.Player == data.Player ? 1 : 0;
+			});
+
 			generatePieChart(d, checkedAttributes);
 		})
 		.on('click', function(d) {
@@ -166,12 +192,15 @@ const updateScatterPlotXValues = (playerCheckbox) => {
 		})
 		.on('mouseout', function(d) {
 			tooltip.transition().duration(500).style('opacity', 0);
+
+			svg.selectAll('.projectionLine').style('opacity', 0);
 		});
 
 	dot.exit().remove();
 
 	addOrRemoveDotLabels();
 	updateScatterPlotDotAndLabelPositions();
+	addOrRemoveProjectionLines();
 };
 
 const updatePlot = () => {

--- a/visualization/scatter_plot.js
+++ b/visualization/scatter_plot.js
@@ -56,10 +56,27 @@ const updateYAxis = () => {
 const updateXAxis = () => {
 	if (shownPlayers.length == 0) return;
 
-	//TODO: If we don't start at x=0, will need to re-calculate slope
+	//TODO: If we want to dynamically change the min value of the x-axis
 	// xScale.domain([ d3.min(shownPlayers, xValue) - 10, d3.max(shownPlayers, xValue) + 20 ]);
 	xScale.domain([ 0, d3.max(shownPlayers, xValue) + 20 ]);
 	svg.select('.x-axis').call(xAxis);
+};
+
+const slope = (d) => {
+	const rise = yValue(d);
+	const run = d.G;
+	return rise / run;
+};
+
+const calculateProjectedStartXValue = () => {
+	const xMin = xScale.domain()[0];
+	return xScale(xMin);
+};
+
+const calculateProjectedStartYValue = (d) => {
+	const xMin = xScale.domain()[0];
+	const projectedStart = xMin * slope(d);
+	return yScale(projectedStart);
 };
 
 const calculateProjectedFinishXValue = () => {
@@ -69,10 +86,7 @@ const calculateProjectedFinishXValue = () => {
 
 const calculateProjectedFinishYValue = (d) => {
 	const xMax = xScale.domain()[1];
-	const rise = yValue(d);
-	const run = d.G;
-	const slope = rise / run;
-	const projectedFinish = xMax * slope;
+	const projectedFinish = xMax * slope(d);
 	return yScale(projectedFinish);
 };
 
@@ -85,8 +99,8 @@ const addOrRemoveProjectionLines = () => {
 		.enter()
 		.append('line')
 		.attr('class', 'projectionLine')
-		.attr('x1', xScale(0))
-		.attr('y1', yScale(0))
+		.attr('x1', calculateProjectedStartXValue())
+		.attr('y1', (d) => calculateProjectedStartYValue(d))
 		.attr('x2', calculateProjectedFinishXValue())
 		.attr('y2', (d) => calculateProjectedFinishYValue(d))
 		.style('stroke', 'black')
@@ -114,6 +128,8 @@ const updateScatterPlotDotAndLabelPositions = () => {
 
 	svg
 		.selectAll('.projectionLine')
+		.attr('x1', calculateProjectedStartXValue())
+		.attr('y1', (d) => calculateProjectedStartYValue(d))
 		.attr('x2', calculateProjectedFinishXValue())
 		.attr('y2', (d) => calculateProjectedFinishYValue(d));
 };


### PR DESCRIPTION
Adding line projections for each player up to the max value of x.

Start of the projection will occur on the y-axis - works for both x-axis starting at 0 and changing with shown players.